### PR TITLE
Respect system theme preference when no stored setting

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,7 +219,17 @@
 
   const themeBtn=document.getElementById('themeBtn');
   function loadTheme(){
-    try{ const t=localStorage.getItem(THEME_KEY); if(t){document.documentElement.setAttribute('data-theme', t);} }catch(e){}
+    const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    try{
+      const t = localStorage.getItem(THEME_KEY);
+      if(t){
+        document.documentElement.setAttribute('data-theme', t);
+      }else{
+        document.documentElement.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
+      }
+    }catch(e){
+      document.documentElement.setAttribute('data-theme', prefersDark ? 'dark' : 'light');
+    }
   }
   function setTheme(t){
     document.documentElement.setAttribute('data-theme', t);


### PR DESCRIPTION
## Summary
- Default to OS-level `prefers-color-scheme` when no saved theme is found

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b08381f5483239da47d3641d5ee32