### PR TITLE
Document CSV schema and link from UI

### DIFF
--- a/CSV_SCHEMA.md
+++ b/CSV_SCHEMA.md
@@ -1,0 +1,26 @@
+# CSV Schema
+
+This document outlines the required columns for the CSV naming schema consumed by the DM Name Generator.
+
+## Required Columns
+
+| Column | Description | Example |
+| --- | --- | --- |
+| `generator` | Name of the generator category such as `Campaign`, `AdGroup`, or `Asset`. | `Campaign` |
+| `field_order` | Position of the field in the generated name; numeric sequence starting at 1. | `1` |
+| `field` | Key used to look up values for this segment of the name. | `objective` |
+| `optional` | Whether the field may be omitted (`TRUE` or `FALSE`). | `FALSE` |
+| `label` | Human‑readable label shown in the UI. | `Objective` |
+| `code` | Abbreviated code inserted into the generated name. | `obj` |
+| `delimiter` | Character(s) appended after the field's value. | `_` |
+| `case` | Case transformation applied to the field's value (e.g., `lower`, `upper`, `title`). | `lower` |
+
+## Example
+
+```
+generator,field_order,field,optional,label,code,delimiter,case
+Campaign,1,objective,FALSE,Objective,obj,_,lower
+Campaign,2,region,TRUE,Region,reg,-,lower
+```
+
+Use UTF-8 encoding and ensure the column headers exactly match the names above.

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
     <label for="csvUpload">Upload CSV naming schema</label>
     <input type="file" id="csvUpload" accept=".csv" aria-describedby="csvInstructions">
     <div id="csvDropZone" tabindex="0" aria-label="CSV drop zone">
-      <p id="csvInstructions">Select a CSV file or drag it into this area.</p>
+      <p id="csvInstructions">Select a CSV file or drag it into this area. See the <a href="CSV_SCHEMA.md" target="_blank">CSV schema</a> for required columns.</p>
     </div>
     <div id="pairs"></div>
   </main>


### PR DESCRIPTION
## Summary
- add CSV schema documentation describing required columns and example
- link CSV schema from upload instructions in the UI

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b2bd1405883239e64dd4640b15db1