### PR TITLE
Reposition CSV upload block above footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,12 +23,12 @@
   </header>
 
   <main id="main" class="container">
+    <div id="pairs"></div>
     <label for="csvUpload">Upload CSV naming schema</label>
     <input type="file" id="csvUpload" accept=".csv" aria-describedby="csvInstructions">
     <div id="csvDropZone" tabindex="0" aria-label="CSV drop zone">
       <p id="csvInstructions">Select a CSV file or drag it into this area. See the <a href="CSV_SCHEMA.md" target="_blank">CSV schema</a> for required columns.</p>
     </div>
-    <div id="pairs"></div>
   </main>
 
   <footer class="container" style="margin-top:16px">

--- a/styles.css
+++ b/styles.css
@@ -135,13 +135,20 @@
     .copyright{color:var(--muted); font-size:12px; margin-left:2px}
 
     /* CSV upload */
+    label[for="csvUpload"]{
+      display:block;
+      margin-top:32px;
+    }
+    #csvUpload{
+      margin-top:8px;
+    }
     #csvDropZone {
       border:2px dashed var(--border);
       border-radius:12px;
       padding:20px;
       text-align:center;
       color:var(--muted);
-      margin-top:16px;
+      margin:16px 0 32px;
       cursor:pointer;
     }
     #csvDropZone:hover,


### PR DESCRIPTION
## Summary
- relocate CSV upload controls to the bottom of the main container so they're positioned above the footer
- add spacing and block-level styling for upload controls to match container layout

## Testing
- `npm test` *(fails: package.json not found)*
- Manual browser test to ensure CSV upload appears above footer and drag-and-drop works

------
https://chatgpt.com/codex/tasks/task_e_689b310dd1c48323a88870cf1e614cea